### PR TITLE
Added Simple Touch Event

### DIFF
--- a/src/jquery.big-slide.js
+++ b/src/jquery.big-slide.js
@@ -89,7 +89,6 @@
       }
     });
 
-    // Adds support for a Touch, which in turn fires the click
     menuLink.on('touchend', function(e){
       menuLink.trigger('click.bigSlide');
       e.preventDefault();


### PR DESCRIPTION
Added a `touchend` event that will trigger the click function on the given `menuLink`. This makes the action smoother on tablets/mobile and avoids that odd delay when a tablet substitutes a click for what is, in reality, a touch.
