### PR TITLE
Added "Active Class' to menuLink

### DIFF
--- a/src/jquery.big-slide.js
+++ b/src/jquery.big-slide.js
@@ -50,7 +50,7 @@
       menu._state = 'open';
       menu.css(settings.side, '0');
       push.css(settings.side, width);
-      menuLink.addClass(settings.activeBtn, activeBtn);
+      menuLink.addClass(settings.activeBtn);
     };
 
     menu.close = function() {


### PR DESCRIPTION
added 'activeBtn':'menu-open' to give the menu button an extra class when the slide is open.
