### PR TITLE
Provide access to bigSlide components

### DIFF
--- a/src/jquery.big-slide.js
+++ b/src/jquery.big-slide.js
@@ -118,7 +118,10 @@
     }
 
     controller.init();
-
+    
+    // allow public access to the bigSlide components
+    menuLink.data('bigSlide', {model:model, view:view, controller:controller});
+    return this;
   };
 
 }(jQuery));

--- a/src/jquery.big-slide.js
+++ b/src/jquery.big-slide.js
@@ -3,7 +3,7 @@
 
   $.fn.bigSlide = function(options) {
     // store the menuLink in a way that is globally accessible
-    var menuLink = this;
+    var menuLink = this, pub;
 
     // plugin settings
     var settings = $.extend({
@@ -119,8 +119,10 @@
 
     controller.init();
     
+    pub = {model:model, view:view, controller:controller, settings:settings};
+    
     // allow public access to the bigSlide components
-    menuLink.data('bigSlide', {model:model, view:view, controller:controller, settings:settings});
+    menuLink.data('bigSlide', pub);
     return this;
   };
 

--- a/src/jquery.big-slide.js
+++ b/src/jquery.big-slide.js
@@ -120,7 +120,7 @@
     controller.init();
     
     // allow public access to the bigSlide components
-    menuLink.data('bigSlide', {model:model, view:view, controller:controller});
+    menuLink.data('bigSlide', {model:model, view:view, controller:controller, settings:settings});
     return this;
   };
 


### PR DESCRIPTION
I think it'd be good to give developers access to the bigSlide internals. While it may be more appropriate to provide only a subset of functions through a more formal public API, I think providing access to all the MVC components to developers that want to access them is fine as long as they know that the internals are subject to change.