### PR TITLE
Use addBack instead of deprecated andSelf

### DIFF
--- a/src/jquery.big-slide.js
+++ b/src/jquery.big-slide.js
@@ -246,7 +246,7 @@
         // this makes my eyes bleed, but adding it back in as it's a highly requested feature
         if (settings.easyClose) {
           $(document).on('click.bigSlide', function(e) {
-           if (!$(e.target).parents().andSelf().is(menuLink) && !$(e.target).closest(settings.menu).length && controller.getState() === 'open')  {
+           if (!$(e.target).parents().addBack().is(menuLink) && !$(e.target).closest(settings.menu).length && controller.getState() === 'open')  {
              view.toggleClose();
            }
           });


### PR DESCRIPTION
Support for `andSelf` has been removed in jQuery 3, but `addBack` does the same thing since 1.8
See http://api.jquery.com/andself/

This fixes `easyClose` when jQuery 3+ is used.